### PR TITLE
adding cid to error message

### DIFF
--- a/store/w3store.go
+++ b/store/w3store.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"sync"
@@ -193,7 +194,7 @@ func (s W3StoreSubscriber) downloadChainedEntries(ctx context.Context, fromExclu
 		}
 
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to download car")
+			return nil, errors.Wrap(err, fmt.Sprintf("failed to download car for CID link %s", url))
 		}
 
 		if got.StatusCode() != http.StatusOK {


### PR DESCRIPTION
## Description

we are receiving  errors for w3storage file downloads, adding the cid to the error message so we can debug

<img width="1652" alt="Screen Shot 2023-01-03 at 9 36 44 AM" src="https://user-images.githubusercontent.com/5998100/210410303-5e22a338-f25d-4984-a329-579d781a1251.png">
