### PR TITLE
fixing memory for task test increase the UDP receive buffer size

### DIFF
--- a/.github/workflows/actions/go-test-setup.yml
+++ b/.github/workflows/actions/go-test-setup.yml
@@ -1,0 +1,7 @@
+runs:
+  using: "composite"
+  steps:
+    - name: increase the UDP receive buffer size # see https://github.com/lucas-clemente/quic-go/wiki/UDP-Receive-Buffer-Size
+      shell: bash
+      run: sysctl -w net.core.rmem_max=2500000
+      if: ${{ matrix.os == 'ubuntu' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,9 +51,12 @@ jobs:
           postgresql db: 'postgres'
           postgresql user: 'postgres'
           postgresql password: 'postgres'
-
       - name: Setup gotestsum
         run: go install gotest.tools/gotestsum@latest
+
+      - name: Run repo-specific setup
+        uses: ./.github/actions/go-test-setup
+        if: hashFiles('./.github/actions/go-test-setup') != ''
 
       - name: Test
         env:


### PR DESCRIPTION
## Description

https://github.com/data-preservation-programs/ValidationBot/issues/39

we are getting the following error on ci tests for task -- :

```
failed to sufficiently increase receive buffer size (was: 208 kiB, wanted: 2048 kiB, got: 416 kiB). See https://github.com/lucas-clemente/quic-go/wiki/UDP-Receive-Buffer-Size for details.
```

I found a reference in `go-libp2p` that addresses this same issue and implements the fix discussed in the `quic-go` guide

https://github.com/libp2p/go-libp2p/pull/1323