### PR TITLE
trim bad pathing?

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -117,7 +117,7 @@ func setConfig(ctx context.Context, configPath string) (*config, error) {
 					if err != nil {
 						panic(err)
 					}
-					return absPath
+					return strings.Trim(absPath, " /")
 				}(),
 			},
 		},

--- a/role/auditor/rpc.go
+++ b/role/auditor/rpc.go
@@ -81,7 +81,13 @@ func (r *ClientRPC) CallServer(
 	// calls /path/to/ValidationBot/validation_bot validation-rpc
 	cmd := exec.CommandContext(ctx, dir, "validation-rpc")
 	cmd.Dir = absdir
-	cmd.Path = fmt.Sprintf("%s/validation_bot", r.execPath)
+
+	r.log.Info().Str("execution path", r.execPath).Msg("executing validation bot rpc from path")
+	if r.execPath == "" || r.execPath == "/" {
+		cmd.Path = "./validation_bot"
+	} else {
+		cmd.Path = fmt.Sprintf("%s/validation_bot", r.execPath)
+	}
 
 	stdout, _ := cmd.StdoutPipe()
 	defer stdout.Close()


### PR DESCRIPTION
need to fix pathing issue with `fork/exec //validation_bot`

```
Log labels
--
  | __aws_cloudwatch_log_group | /ecs/ValidationBot-Auditor
  | __aws_cloudwatch_owner | 258998852000
  | __extra_region | us-west-2
Detected fields
  | Time | 1677014835077
  | caller | "/app/role/auditor/auditor.go:160"
  | error | "failed to start validation server: fork/exec //validation_bot: no such file or directory"
  | level | "error"
  | message | "failed to validate"
  | role | "auditor"
  | task | "{\"type\":\"retrieval\",\"definitionId\":\"85a1751a-077e-449a-8d4d-ed7c3ad509a3\",\"target\":\"f01611097\",\"taskId\":\"703cc7f1-aada-48ba-bc5c-3276ca2ae912\",\"input\":{\"protocolPreference\":[\"GraphSync\"],\"pieceCid\":\"baga6ea4seaqoxy2gpkdflkcn3rres4oucgmotcxbqm4rehiuev4puno7vk5hybi\",\"label\":\"uAXCg5AIgWf-IoZhxk_W-CLZFWE0suYxUWUueqNWt8DQSBKi9RXU\",\"dealId\":\"7801229\",\"client\":\"f01787692\"}}"
  | time | "2023-02-21T21:27:15Z"
  | tsNs | 1677014835077000000
```

